### PR TITLE
Re initialised the package.json file and added the dependencies to it - issue #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,24 @@
 {
   "name": "live-tools",
-  "version": "1.0-beta.1",
-  "description": "A node.js based system providing various functionality during live broadcasts.",
+  "version": "1.0.0",
+  "description": "A node.js based system for providing show critical services on XTV live broadcasts.",
   "main": "index.js",
+  "directories": {
+    "lib": "lib"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xtv-online/live-tools.git"
+    "url": "git+https://github.com/And-Stuff/live-tools.git"
   },
   "author": "Sam Hutchings, Nik Rahmel",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/xtv-online/live-tools/issues"
+    "url": "https://github.com/And-Stuff/live-tools/issues"
   },
-  "homepage": "https://github.com/xtv-online/live-tools#readme",
+  "homepage": "https://github.com/And-Stuff/live-tools#readme",
   "dependencies": {
     "atem": "^0.1.4",
     "colour": "^0.7.1",


### PR DESCRIPTION
@Niwreg @HansVanEijsden I re-initialized the `package.json` and now i can clone the repo, do a `npm install` and all the packages are installed, resolving issue #1 . Can one of you confirm that this fix also works on your side?

Also not sure if the url's pointing to the git repo should be changed to the and-stuff repository or should remain the original xtv-online git url's. The `npm init` made them point to the and-stuff one. Talking about line number 14, 19 and 21 on the latest commit. What do you guys think?